### PR TITLE
Issue #24 fix character classes

### DIFF
--- a/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
+++ b/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
@@ -8,47 +8,41 @@ trait transform {
 	private val Numbers = '0' to '9'
 	private val UpperCase = 'A' to 'Z'
 
-	private val filter: ((Array[Char], (Char => Boolean)) => String) = (ca, f) =>
-		ca.filter(c => f(c)).mkString
+	val filterAlpha: StringTransform =
+		_.filter(c => LowerCase.contains(c) || UpperCase.contains(c))
 
-	private val filterNot: ((Array[Char], (Char => Boolean)) => String) = (ca, f) =>
-		ca.filterNot(c => f(c)).mkString
+	val filterNotAlpha: StringTransform =
+		_.filterNot(c => LowerCase.contains(c) || UpperCase.contains(c))
 
-	val filterAlpha: StringTransform = (ca) =>
-		filter(ca, c => LowerCase.contains(c) || UpperCase.contains(c))
+	val filterAlphaNumeric: StringTransform =
+		_.filter(c => LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c))
 
-	val filterNotAlpha: StringTransform = (ca) =>
-		filterNot(ca, c => LowerCase.contains(c) || UpperCase.contains(c))
+	val filterNotAlphaNumeric: StringTransform =
+		_.filterNot(c => LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c))
 
-	val filterAlphaNumeric: StringTransform = (ca) =>
-		filter(ca, c => LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c))
+	val filterAscii: StringTransform = _.filter(Ascii.contains)
 
-	val filterNotAlphaNumeric: StringTransform = (ca) =>
-		filterNot(ca, c => LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c))
+	val filterNotAscii: StringTransform = _.filterNot(Ascii.contains)
 
-	val filterAscii: StringTransform = (ca) => filter(ca, Ascii.contains)
+	val filterExtendedAscii: StringTransform = _.filter(ExtendedAscii.contains)
 
-	val filterNotAscii: StringTransform = (ca) => filterNot(ca, Ascii.contains)
+	val filterNotExtendedAscii: StringTransform = _.filterNot(ExtendedAscii.contains)
 
-	val filterExtendedAscii: StringTransform = (ca) => filter(ca, ExtendedAscii.contains)
+	val filterLatin: StringTransform = _.filter(Latin.contains)
 
-	val filterNotExtendedAscii: StringTransform = (ca) => filterNot(ca, ExtendedAscii.contains)
+	val filterNotLatin: StringTransform = _.filterNot(Latin.contains)
 
-	val filterLatin: StringTransform = (ca) => filter(ca, Latin.contains)
+	val filterLowerCase: StringTransform = _.filter(LowerCase.contains)
 
-	val filterNotLatin: StringTransform = (ca) => filterNot(ca, Latin.contains)
+	val filterNotLowerCase: StringTransform = _.filterNot(LowerCase.contains)
 
-	val filterLowerCase: StringTransform = (ca) => filter(ca, LowerCase.contains)
+	val filterNumeric: StringTransform = _.filter(Numbers.contains)
 
-	val filterNotLowerCase: StringTransform = (ca) => filterNot(ca, LowerCase.contains)
+	val filterNotNumeric: StringTransform = _.filterNot(Numbers.contains)
 
-	val filterNumeric: StringTransform = (ca) => filter(ca, Numbers.contains)
+	val filterUpperCase: StringTransform = _.filter(UpperCase.contains)
 
-	val filterNotNumeric: StringTransform = (ca) => filterNot(ca, Numbers.contains)
-
-	val filterUpperCase: StringTransform = (ca) => filter(ca, UpperCase.contains)
-
-	val filterNotUpperCase: StringTransform = (ca) => filterNot(ca, UpperCase.contains)
+	val filterNotUpperCase: StringTransform = _.filterNot(UpperCase.contains)
 
 	val ignoreAlphaCase: StringTransform = (ca) => ca.map(_.toLower)
 }

--- a/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
+++ b/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
@@ -1,14 +1,12 @@
 package com.rockymadden.stringmetric
 
-import scala.collection.immutable.NumericRange
-
 trait transform {
-	private val Ascii = NumericRange.inclusive(0x00, 0x7F, 1)
-	private val ExtendedAscii = NumericRange.inclusive(0x00, 0x7F, 1)
-	private val Latin = NumericRange.inclusive(0x00, 0x24F, 1)
-	private val LowerCase = NumericRange.inclusive(0x61, 0x7A, 1)
-	private val Numbers = NumericRange.inclusive(0x30, 0x39, 1)
-	private val UpperCase = NumericRange.inclusive(0x41, 0x5A, 1)
+	private val Ascii = 0x00.toChar to 0x7F.toChar
+	private val ExtendedAscii = 0x00.toChar to 0x7F.toChar
+	private val Latin = 0x00.toChar to 0x24F.toChar
+	private val LowerCase = 'a' to 'z'
+	private val Numbers = '0' to '9'
+	private val UpperCase = 'A' to 'Z'
 
 	private val filter: ((Array[Char], (Char => Boolean)) => String) = (ca, f) =>
 		ca.filter(c => f(c)).mkString
@@ -17,50 +15,46 @@ trait transform {
 		ca.filterNot(c => f(c)).mkString
 
 	val filterAlpha: StringTransform = (ca) => filter(ca, c => {
-		val ci = c.toInt
-		LowerCase.contains(ci) || UpperCase.contains(ci)
+		LowerCase.contains(c) || UpperCase.contains(c)
 	})
 
 	val filterNotAlpha: StringTransform = (ca) => filterNot(ca, c => {
-		val ci = c.toInt
-		LowerCase.contains(ci) || UpperCase.contains(ci)
+		LowerCase.contains(c) || UpperCase.contains(c)
 	})
 
 	val filterAlphaNumeric: StringTransform = (ca) => filter(ca, c => {
-		val ci = c.toInt
-		LowerCase.contains(ci) || UpperCase.contains(ci) || Numbers.contains(ci)
+		LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c)
 	})
 
 	val filterNotAlphaNumeric: StringTransform = (ca) => filterNot(ca, c => {
-		val ci = c.toInt
-		LowerCase.contains(ci) || UpperCase.contains(ci) || Numbers.contains(ci)
+		LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c)
 	})
 
-	val filterAscii: StringTransform = (ca) => filter(ca, c => Ascii.contains(c.toInt))
+	val filterAscii: StringTransform = (ca) => filter(ca, Ascii.contains)
 
-	val filterNotAscii: StringTransform = (ca) => filterNot(ca, c => Ascii.contains(c.toInt))
+	val filterNotAscii: StringTransform = (ca) => filterNot(ca, Ascii.contains)
 
-	val filterExtendedAscii: StringTransform = (ca) => filter(ca, c => ExtendedAscii.contains(c.toInt))
+	val filterExtendedAscii: StringTransform = (ca) => filter(ca, ExtendedAscii.contains)
 
-	val filterNotExtendedAscii: StringTransform = (ca) => filterNot(ca, c => ExtendedAscii.contains(c.toInt))
+	val filterNotExtendedAscii: StringTransform = (ca) => filterNot(ca, ExtendedAscii.contains)
 
-	val filterLatin: StringTransform = (ca) => filter(ca, c => Latin.contains(c.toInt))
+	val filterLatin: StringTransform = (ca) => filter(ca, Latin.contains)
 
-	val filterNotLatin: StringTransform = (ca) => filterNot(ca, c => Latin.contains(c.toInt))
+	val filterNotLatin: StringTransform = (ca) => filterNot(ca, Latin.contains)
 
-	val filterLowerCase: StringTransform = (ca) => filter(ca, c => LowerCase.contains(c.toInt))
+	val filterLowerCase: StringTransform = (ca) => filter(ca, LowerCase.contains)
 
-	val filterNotLowerCase: StringTransform = (ca) => filterNot(ca, c => LowerCase.contains(c.toInt))
+	val filterNotLowerCase: StringTransform = (ca) => filterNot(ca, LowerCase.contains)
 
-	val filterNumeric: StringTransform = (ca) => filter(ca, c => Numbers.contains(c.toInt))
+	val filterNumeric: StringTransform = (ca) => filter(ca, Numbers.contains)
 
-	val filterNotNumeric: StringTransform = (ca) => filterNot(ca, c => Numbers.contains(c.toInt))
+	val filterNotNumeric: StringTransform = (ca) => filterNot(ca, Numbers.contains)
 
-	val filterUpperCase: StringTransform = (ca) => filter(ca, c => UpperCase.contains(c.toInt))
+	val filterUpperCase: StringTransform = (ca) => filter(ca, UpperCase.contains)
 
-	val filterNotUpperCase: StringTransform = (ca) => filterNot(ca, c => UpperCase.contains(c.toInt))
+	val filterNotUpperCase: StringTransform = (ca) => filterNot(ca, UpperCase.contains)
 
-	val ignoreAlphaCase: StringTransform = (ca) => ca.map(c => if (c >= 65 && c <= 90) (c + 32).toChar else c)
+	val ignoreAlphaCase: StringTransform = (ca) => ca.map(_.toLower)
 }
 
 object transform extends transform

--- a/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
+++ b/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
@@ -3,12 +3,12 @@ package com.rockymadden.stringmetric
 import scala.collection.immutable.NumericRange
 
 trait transform {
-	private val Ascii = NumericRange(0x00, 0x7F, 1)
-	private val ExtendedAscii = NumericRange(0x00, 0x7F, 1)
-	private val Latin = NumericRange(0x00, 0x24F, 1)
-	private val LowerCase = NumericRange(0x61, 0x7A, 1)
-	private val Numbers = NumericRange(0x30, 0x39, 1)
-	private val UpperCase = NumericRange(0x41, 0x5A, 1)
+	private val Ascii = NumericRange.inclusive(0x00, 0x7F, 1)
+	private val ExtendedAscii = NumericRange.inclusive(0x00, 0x7F, 1)
+	private val Latin = NumericRange.inclusive(0x00, 0x24F, 1)
+	private val LowerCase = NumericRange.inclusive(0x61, 0x7A, 1)
+	private val Numbers = NumericRange.inclusive(0x30, 0x39, 1)
+	private val UpperCase = NumericRange.inclusive(0x41, 0x5A, 1)
 
 	private val filter: ((Array[Char], (Char => Boolean)) => String) = (ca, f) =>
 		ca.filter(c => f(c)).mkString

--- a/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
+++ b/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
@@ -1,24 +1,22 @@
 package com.rockymadden.stringmetric
 
 trait transform {
-	private val Ascii = 0x00.toChar to 0x7F.toChar
-	private val ExtendedAscii = 0x00.toChar to 0x7F.toChar
-	private val Latin = 0x00.toChar to 0x24F.toChar
-	private val LowerCase = 'a' to 'z'
-	private val Numbers = '0' to '9'
-	private val UpperCase = 'A' to 'Z'
+	private lazy val Ascii = 0x00.toChar to 0x7F.toChar
+	private lazy val ExtendedAscii = 0x00.toChar to 0x7F.toChar
+	private lazy val Latin = 0x00.toChar to 0x24F.toChar
+	private lazy val LowerCase = 'a' to 'z'
+	private lazy val Numbers = '0' to '9'
+	private lazy val UpperCase = 'A' to 'Z'
+	private lazy val Alpha = LowerCase ++ UpperCase
+	private lazy val AlphaNumeric = Alpha ++ Numbers
 
-	val filterAlpha: StringTransform =
-		_.filter(c => LowerCase.contains(c) || UpperCase.contains(c))
+	val filterAlpha: StringTransform = _.filter(Alpha.contains)
 
-	val filterNotAlpha: StringTransform =
-		_.filterNot(c => LowerCase.contains(c) || UpperCase.contains(c))
+	val filterNotAlpha: StringTransform = _.filterNot(Alpha.contains)
 
-	val filterAlphaNumeric: StringTransform =
-		_.filter(c => LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c))
+	val filterAlphaNumeric: StringTransform = _.filter(AlphaNumeric.contains)
 
-	val filterNotAlphaNumeric: StringTransform =
-		_.filterNot(c => LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c))
+	val filterNotAlphaNumeric: StringTransform = _.filterNot(AlphaNumeric.contains)
 
 	val filterAscii: StringTransform = _.filter(Ascii.contains)
 

--- a/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
+++ b/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
@@ -44,7 +44,7 @@ trait transform {
 
 	val filterNotUpperCase: StringTransform = _.filterNot(UpperCase.contains)
 
-	val ignoreAlphaCase: StringTransform = (ca) => ca.map(_.toLower)
+	val ignoreAlphaCase: StringTransform = _.map(c => if (UpperCase contains c) c.toLower else c)
 }
 
 object transform extends transform

--- a/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
+++ b/core/src/main/scala/com/rockymadden/stringmetric/transform.scala
@@ -14,21 +14,17 @@ trait transform {
 	private val filterNot: ((Array[Char], (Char => Boolean)) => String) = (ca, f) =>
 		ca.filterNot(c => f(c)).mkString
 
-	val filterAlpha: StringTransform = (ca) => filter(ca, c => {
-		LowerCase.contains(c) || UpperCase.contains(c)
-	})
+	val filterAlpha: StringTransform = (ca) =>
+		filter(ca, c => LowerCase.contains(c) || UpperCase.contains(c))
 
-	val filterNotAlpha: StringTransform = (ca) => filterNot(ca, c => {
-		LowerCase.contains(c) || UpperCase.contains(c)
-	})
+	val filterNotAlpha: StringTransform = (ca) =>
+		filterNot(ca, c => LowerCase.contains(c) || UpperCase.contains(c))
 
-	val filterAlphaNumeric: StringTransform = (ca) => filter(ca, c => {
-		LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c)
-	})
+	val filterAlphaNumeric: StringTransform = (ca) =>
+		filter(ca, c => LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c))
 
-	val filterNotAlphaNumeric: StringTransform = (ca) => filterNot(ca, c => {
-		LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c)
-	})
+	val filterNotAlphaNumeric: StringTransform = (ca) =>
+		filterNot(ca, c => LowerCase.contains(c) || UpperCase.contains(c) || Numbers.contains(c))
 
 	val filterAscii: StringTransform = (ca) => filter(ca, Ascii.contains)
 

--- a/core/src/test/scala/com/rockymadden/stringmetric/transformSpec.scala
+++ b/core/src/test/scala/com/rockymadden/stringmetric/transformSpec.scala
@@ -6,17 +6,17 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"filterAlpha()" should {
 		"return transformed" in {
 			filterAlpha(
-				("aBc123" + 0x250.toChar).toCharArray
-			) must beEqualTo("aBc".toCharArray)
+				("aBc123zZ" + 0x5B.toChar + 0x7B.toChar).toCharArray
+			) must beEqualTo("aBczZ".toCharArray)
 		}
 	}
 
 	"filterNotAlpha()" should {
 		"return transformed" in {
 			filterNotAlpha(
-				("aBc123" + 0x250.toChar).toCharArray
+				("aBc123zZ" + 0x5B.toChar + 0x7B.toChar).toCharArray
 			) must beEqualTo(
-				("123" + 0x250.toChar).toCharArray
+				("123" + 0x5B.toChar + 0x7B.toChar).toCharArray
 			)
 		}
 	}
@@ -24,17 +24,17 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"filterAlphaNumeric()" should {
 		"return transformed" in {
 			filterAlphaNumeric(
-				("aBc123" + 0x250.toChar).toCharArray
-			) must beEqualTo("aBc123".toCharArray)
+				("aBc123zZ9" + 0x3A.toChar + 0x5B.toChar + 0x7B.toChar).toCharArray
+			) must beEqualTo("aBc123zZ9".toCharArray)
 		}
 	}
 
 	"filterNotAlphaNumeric()" should {
 		"return transformed" in {
 			filterNotAlphaNumeric(
-				("aBc123" + 0x250.toChar).toCharArray
+				("aBc123zZ9" + 0x3A.toChar + 0x5B.toChar + 0x7B.toChar).toCharArray
 			) must beEqualTo(
-				("" + 0x250.toChar).toCharArray
+				("" + 0x3A.toChar + 0x5B.toChar + 0x7B.toChar).toCharArray
 			)
 		}
 	}
@@ -42,15 +42,15 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"filterAscii()" should {
 		"return transformed" in {
 			filterAscii(
-				("aBc" + 0x80.toChar).toCharArray
-			) must beEqualTo("aBc".toCharArray)
+				("aBc" + 0x7F.toChar + 0x100.toChar).toCharArray
+			) must beEqualTo(("aBc" + 0x7F.toChar).toCharArray)
 		}
 	}
 
 	"filterNotAscii()" should {
 		"return transformed" in {
 			filterNotAscii(
-				("aBc" + 0x100.toChar).toCharArray
+				("aBc" + 0x7F.toChar + 0x100.toChar).toCharArray
 			) must beEqualTo(
 				("" + 0x100.toChar).toCharArray
 			)
@@ -60,15 +60,15 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"filterExtendedAscii()" should {
 		"return transformed" in {
 			filterExtendedAscii(
-				("aBc" + 0x100.toChar).toCharArray
-			) must beEqualTo("aBc".toCharArray)
+				("aBc" + 0x7F.toChar + 0x100.toChar).toCharArray
+			) must beEqualTo(("aBc" + 0x7F.toChar).toCharArray)
 		}
 	}
 
 	"filterNotExtendedAscii()" should {
 		"return transformed" in {
 			filterNotExtendedAscii(
-				("aBc" + 0x250.toChar).toCharArray
+				("aBc" + 0x7F.toChar + 0x250.toChar).toCharArray
 			) must beEqualTo(
 				("" + 0x250.toChar).toCharArray
 			)
@@ -78,15 +78,15 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"filterLatin()" should {
 		"return transformed" in {
 			filterLatin(
-				("aBc" + 0x250.toChar).toCharArray
-			) must beEqualTo("aBc".toCharArray)
+				("aBc" + 0x24F.toChar + 0x250.toChar).toCharArray
+			) must beEqualTo(("aBc" + 0x24F.toChar).toCharArray)
 		}
 	}
 
 	"filterNotLatin()" should {
 		"return transformed" in {
 			filterNotLatin(
-				("aBc" + 0x300.toChar).toCharArray
+				("aBc" + 0x24F.toChar + 0x300.toChar).toCharArray
 			) must beEqualTo(
 				("" + 0x300.toChar).toCharArray
 			)
@@ -96,15 +96,15 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"filterLowerCase()" should {
 		"return transformed" in {
 			filterLowerCase(
-				"aBc123" + 0x250.toChar
-			) must beEqualTo("ac".toCharArray)
+				"aBc123z" + 0x250.toChar
+			) must beEqualTo("acz".toCharArray)
 		}
 	}
 
 	"filterNotLowerCase()" should {
 		"return transformed" in {
 			filterNotLowerCase(
-				("aBc123" + 0x250.toChar).toCharArray
+				("aBc123z" + 0x250.toChar).toCharArray
 			) must beEqualTo(
 				("B123" + 0x250.toChar).toCharArray
 			)
@@ -114,15 +114,15 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"filterNumeric()" should {
 		"return transformed" in {
 			filterNumeric(
-				("aBc123" + 0x250.toChar).toCharArray
-			) must beEqualTo("123".toCharArray)
+				("aBc1239" + 0x250.toChar).toCharArray
+			) must beEqualTo("1239".toCharArray)
 		}
 	}
 
 	"filterNotNumeric()" should {
 		"return transformed" in {
 			filterNotNumeric(
-				("aBc123" + 0x250.toChar).toCharArray
+				("aBc1239" + 0x250.toChar).toCharArray
 			) must beEqualTo(
 				("aBc" + 0x250.toChar).toCharArray
 			)
@@ -132,15 +132,15 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"filterUpperCase()" should {
 		"return transformed" in {
 			filterUpperCase(
-				("aBc123" + 0x250.toChar).toCharArray
-			) must beEqualTo("B".toCharArray)
+				("aBc123Z" + 0x250.toChar).toCharArray
+			) must beEqualTo("BZ".toCharArray)
 		}
 	}
 
 	"filterNotUpperCase()" should {
 		"return transformed" in {
 			filterNotUpperCase(
-				("aBc123" + 0x250.toChar).toCharArray
+				("aBc123Z" + 0x250.toChar).toCharArray
 			) must beEqualTo(
 				("ac123" + 0x250.toChar).toCharArray
 			)
@@ -150,9 +150,9 @@ object transformSpec extends org.specs2.mutable.SpecificationWithJUnit {
 	"ignoreAlphaCase()" should {
 		"return transformed" in {
 			ignoreAlphaCase(
-				("aBc123" + 0x250.toChar).toCharArray
+				("aBc123zZ" + 0x250.toChar).toCharArray
 			) must beEqualTo(
-				("abc123" + 0x250.toChar).toCharArray
+				("abc123zz" + 0x250.toChar).toCharArray
 			)
 		}
 	}


### PR DESCRIPTION
Fixes #24. Apart from including the missing characters (`z`, `Z`, and `9`) in their respective classes and filters, this change should yield equal results as the upstream version.

I didn't want to change the functionality drastically not to break existing code, but this trait is actually reinventing the character classes already available on Scala's `Char` class. These include `isLower`, `isUpper`, `toLower`, `isLetter,`isDigit`, etc.

I would suggest deprecating this trait and use the following existing alternatives (compatible with the `StringTransform` type):
- `_.filter(_.isLetter)` instead of `filterAlpha`
- `_.filterNot(_.isLetter)` instead of `filterNotAlpha`
- `_.filter(_.isDigit)` instead of `filterNumeric`
- `_.filterNot(_.isDigit)` instead of `filterNotNumeric`
- `_.filter(_.isLetterOrDigit)` instead of `filterAlphaNumeric`
- `_.filterNot(_.isLetterOrDigit)` instead of `filterNotAlphaNumeric`
- `_.filter(_.isLower)` instead of `filterLowerCase`
- `_.filterNot(_.isLower)` instead of `filterNotLowerCase`
- `_.filter(_.isUpper)` instead of `filterUpperCase`
- `_.filterNot(_.isUpper)` instead of `filterNotUpperCase`
- `_.map(_.toLower)` instead of `ignoreAlphaCase`

They are not equivalent, but they are part of the standard library, and I would argue that they are much more accurate than the existing filters.
